### PR TITLE
Mint Authority Functions and Python Bindings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,10 @@ node_modules
 test-ledger
 .yarn
 .env
+
+# Python virtual environment
+venv/
+env/
+.env/
+.venv/
+ENV/

--- a/.gitignore
+++ b/.gitignore
@@ -1,15 +1,74 @@
+# Rust build artifacts
 .anchor
-.DS_Store
-target
+target/
 **/*.rs.bk
-node_modules
-test-ledger
-.yarn
-.env
+Cargo.lock
+**/target/
 
-# Python virtual environment
+# Python
+__pycache__/
+*.py[cod]
+*$py.class
+*.so
+.Python
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+wheels/
+*.egg-info/
+.installed.cfg
+*.egg
+MANIFEST
+
+# Virtual Environment
 venv/
 env/
 .env/
 .venv/
 ENV/
+.python-version
+
+# Node.js
+node_modules/
+.yarn/
+package-lock.json
+yarn.lock
+
+# IDE and Editor files
+.idea/
+.vscode/
+*.swp
+*.swo
+*~
+.DS_Store
+
+# Environment variables
+.env
+.env.local
+.env.*.local
+
+# Test and debug files
+test-ledger/
+coverage/
+.coverage
+htmlcov/
+.pytest_cache/
+.tox/
+.nox/
+.coverage.*
+coverage.xml
+*.cover
+*.py,cover
+.hypothesis/
+
+# Logs
+*.log
+logs/

--- a/Anchor.toml
+++ b/Anchor.toml
@@ -5,8 +5,8 @@ resolution = true
 skip-lint = false
 
 [programs.localnet]
-boring_onchain_queue = "4yfE2VJQmxmcnUhrb8vdz7H8w313EZ3eJh5DbANBgtmd"
-boring_vault_svm = "5ZRnXG4GsUMLaN7w2DtJV1cgLgcXHmuHCmJ2MxoorWCE"
+boring_onchain_queue = "BdrvcPHStDEvM6JUS94DbTEUPkZf7nqAxERWFUG4W4kF"
+boring_vault_svm = "AZewa4rTKhbvyWH6kbqTfJUipYEs3fwgK4qpfdA4qH8e"
 
 [registry]
 url = "https://api.apr.dev"
@@ -17,4 +17,4 @@ wallet = "~/.config/solana/id.json"
 
 [scripts]
 # test = "yarn run ts-mocha -p ./tsconfig.json -t 1000000 tests/*.ts"
-test = "RUST_LOG=error yarn run ts-mocha -p ./tsconfig.json -t 1000000 tests/*.ts"
+test = "RUST_LOG=error yarn run ts-mocha -p ./tsconfig.json -t 1000000 tests/boring-vault-svm.ts && RUST_LOG=error yarn run ts-mocha -p ./tsconfig.json -t 1000000 tests/mint-authority.ts"

--- a/Anchor.toml
+++ b/Anchor.toml
@@ -5,8 +5,8 @@ resolution = true
 skip-lint = false
 
 [programs.localnet]
-boring_onchain_queue = "BdrvcPHStDEvM6JUS94DbTEUPkZf7nqAxERWFUG4W4kF"
-boring_vault_svm = "AZewa4rTKhbvyWH6kbqTfJUipYEs3fwgK4qpfdA4qH8e"
+boring_onchain_queue = "4yfE2VJQmxmcnUhrb8vdz7H8w313EZ3eJh5DbANBgtmd"
+boring_vault_svm = "5ZRnXG4GsUMLaN7w2DtJV1cgLgcXHmuHCmJ2MxoorWCE"
 
 [registry]
 url = "https://api.apr.dev"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2341,9 +2341,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.89"
+version = "1.0.95"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f139b0662de085916d1fb67d2b4169d1addddda1919e696f3252b740b629986e"
+checksum = "02b3e5e68a3a1a02aad3ec490a98007cbc13c37cbe84a3cd7b8e406d76e7f778"
 dependencies = [
  "unicode-ident",
 ]

--- a/programs/boring-onchain-queue/src/lib.rs
+++ b/programs/boring-onchain-queue/src/lib.rs
@@ -29,7 +29,7 @@ use error::*;
 mod state;
 use state::*;
 
-declare_id!("BdrvcPHStDEvM6JUS94DbTEUPkZf7nqAxERWFUG4W4kF");
+declare_id!("4yfE2VJQmxmcnUhrb8vdz7H8w313EZ3eJh5DbANBgtmd");
 
 #[program]
 pub mod boring_onchain_queue {

--- a/programs/boring-onchain-queue/src/lib.rs
+++ b/programs/boring-onchain-queue/src/lib.rs
@@ -29,7 +29,7 @@ use error::*;
 mod state;
 use state::*;
 
-declare_id!("4yfE2VJQmxmcnUhrb8vdz7H8w313EZ3eJh5DbANBgtmd");
+declare_id!("BdrvcPHStDEvM6JUS94DbTEUPkZf7nqAxERWFUG4W4kF");
 
 #[program]
 pub mod boring_onchain_queue {

--- a/programs/boring-vault-svm/src/error.rs
+++ b/programs/boring-vault-svm/src/error.rs
@@ -44,4 +44,14 @@ pub enum BoringErrorCode {
     MaximumSharePremiumExceeded,
     #[msg("Invalid strategist")]
     InvalidStrategist,
+    #[msg("Invalid mint authority")]
+    InvalidMintAuthority,
+    #[msg("Invalid Associated Token Account")]
+    InvalidATA,
+    #[msg("Invalid new mint authority")]
+    InvalidNewMintAuthority,
+    #[msg("No pending mint authority")]
+    NoPendingMintAuthority,
+    #[msg("Invalid amount")]
+    InvalidAmount,
 }

--- a/programs/boring-vault-svm/src/lib.rs
+++ b/programs/boring-vault-svm/src/lib.rs
@@ -40,7 +40,7 @@ pub use state::*;
 
 // Internal module usage
 use utils::{operators, teller};
-declare_id!("AZewa4rTKhbvyWH6kbqTfJUipYEs3fwgK4qpfdA4qH8e");
+declare_id!("5ZRnXG4GsUMLaN7w2DtJV1cgLgcXHmuHCmJ2MxoorWCE");
 
 #[program]
 pub mod boring_vault_svm {

--- a/programs/boring-vault-svm/src/state.rs
+++ b/programs/boring-vault-svm/src/state.rs
@@ -27,6 +27,10 @@ pub struct VaultState {
     pub share_mint: Pubkey,
     pub deposit_sub_account: u8,
     pub withdraw_sub_account: u8,
+    /// Current mint authority for the share token
+    pub current_mint_authority: Pubkey,
+    /// Pending mint authority waiting to be accepted
+    pub pending_mint_authority: Pubkey,
 }
 
 #[derive(AnchorSerialize, AnchorDeserialize, Clone, Debug)]

--- a/tests/mint-authority.ts
+++ b/tests/mint-authority.ts
@@ -1,0 +1,307 @@
+import * as anchor from "@coral-xyz/anchor";
+import { BankrunProvider, startAnchor } from "anchor-bankrun";
+import { Program } from "@coral-xyz/anchor";
+import { PublicKey, Keypair, SystemProgram, LAMPORTS_PER_SOL, SYSVAR_RENT_PUBKEY } from "@solana/web3.js";
+import { assert } from "chai";
+import { BoringVaultSvm } from "../target/types/boring_vault_svm";
+import {
+  TOKEN_PROGRAM_ID,
+  ASSOCIATED_TOKEN_PROGRAM_ID,
+  getAssociatedTokenAddress,
+  TOKEN_2022_PROGRAM_ID,
+} from "@solana/spl-token";
+import { AddedAccount, BanksClient, ProgramTestContext } from "solana-bankrun";
+import * as fs from "fs";
+import { TestHelperService as ths } from "./services/test-helpers";
+import { AccountLayout } from "@solana/spl-token";
+
+// Use WSOL as the base asset
+const WSOL = new PublicKey("So11111111111111111111111111111111111111112");
+
+describe("mint-authority", () => {
+  let provider: BankrunProvider;
+  let program: Program<BoringVaultSvm>;
+  let context: ProgramTestContext;
+  let client: BanksClient;
+  let deployer: Keypair;
+  let authority: Keypair;
+  let newMintAuthority: Keypair;
+  let user: Keypair;
+  let programConfig: PublicKey;
+  let vaultState: PublicKey;
+  let shareMint: PublicKey;
+  let userShareAta: PublicKey;
+  let vaultStateBump: number;
+  let shareMintBump: number;
+  let vaultBaseAssetAta: PublicKey;
+
+  // Load the program's keypair
+  const boringVaultProgramKeypair = JSON.parse(
+    fs.readFileSync("target/deploy/boring_vault_svm-keypair.json", "utf-8")
+  );
+  const boringVaultProgramSigner = Keypair.fromSecretKey(
+    new Uint8Array(boringVaultProgramKeypair)
+  );
+
+  before(async () => {
+    // Generate keypairs
+    deployer = Keypair.generate();
+    authority = Keypair.generate();
+    newMintAuthority = Keypair.generate();
+    user = Keypair.generate();
+
+    // Create base accounts with lamports
+    const baseAccounts: AddedAccount[] = [
+      {
+        address: deployer.publicKey,
+        info: {
+          data: Buffer.alloc(0),
+          executable: false,
+          lamports: LAMPORTS_PER_SOL * 10,
+          owner: SystemProgram.programId,
+          rentEpoch: 0,
+        },
+      },
+      {
+        address: authority.publicKey,
+        info: {
+          lamports: 2 * LAMPORTS_PER_SOL,
+          data: Buffer.alloc(0),
+          owner: SystemProgram.programId,
+          executable: false,
+        },
+      },
+      {
+        address: user.publicKey,
+        info: {
+          lamports: 2 * LAMPORTS_PER_SOL,
+          data: Buffer.alloc(0),
+          owner: SystemProgram.programId,
+          executable: false,
+        },
+      },
+      {
+        address: boringVaultProgramSigner.publicKey,
+        info: {
+          lamports: 2 * LAMPORTS_PER_SOL,
+          data: fs.readFileSync("target/deploy/boring_vault_svm.so"),
+          owner: new PublicKey("BPFLoader2111111111111111111111111111111111"),
+          executable: true,
+        },
+      },
+    ];
+
+    // Set up bankrun provider with all accounts
+    context = await startAnchor(
+      "",
+      [
+        {
+          name: "boring_vault_svm",
+          programId: boringVaultProgramSigner.publicKey,
+        },
+      ],
+      baseAccounts
+    );
+    client = context.banksClient;
+    provider = new BankrunProvider(context);
+    anchor.setProvider(provider);
+    program = anchor.workspace.BoringVaultSvm as Program<BoringVaultSvm>;
+
+    // Find PDAs
+    [programConfig] = PublicKey.findProgramAddressSync(
+      [Buffer.from("config")],
+      program.programId
+    );
+
+    [vaultState, vaultStateBump] = await PublicKey.findProgramAddress(
+      [
+        Buffer.from("boring-vault-state"),
+        Buffer.from([0, 0, 0, 0, 0, 0, 0, 0]), // vault_id = 0
+      ],
+      program.programId
+    );
+
+    [shareMint, shareMintBump] = await PublicKey.findProgramAddress(
+      [Buffer.from("share-token"), vaultState.toBuffer()],
+      program.programId
+    );
+
+    // Set up token accounts
+    vaultBaseAssetAta = await ths.setupATA(
+      context,
+      TOKEN_2022_PROGRAM_ID,
+      WSOL,
+      vaultState,
+      0,
+      true
+    );
+
+    // Set up user's share ATA
+    userShareAta = await ths.setupATA(
+      context,
+      TOKEN_2022_PROGRAM_ID,
+      shareMint,
+      user.publicKey,
+      0,
+      false
+    );
+
+    // Initialize the program
+    const initializeIx = await program.methods
+      .initialize(authority.publicKey)
+      .accounts({
+        signer: deployer.publicKey,
+        program: boringVaultProgramSigner.publicKey,
+        config: programConfig,
+        systemProgram: SystemProgram.programId,
+      })
+      .signers([deployer, boringVaultProgramSigner])
+      .instruction();
+
+    const txResult = await ths.createAndProcessTransaction(
+      context.banksClient,
+      deployer,
+      initializeIx,
+      [deployer, boringVaultProgramSigner]
+    );
+    await ths.expectTxToSucceed(txResult);
+
+    // Deploy vault
+    const deployIx = await program.methods
+      .deploy({
+        authority: authority.publicKey,
+        name: "Test Vault",
+        symbol: "TEST",
+        exchangeRateProvider: authority.publicKey,
+        exchangeRate: new anchor.BN(1000000000),
+        payoutAddress: authority.publicKey,
+        allowedExchangeRateChangeUpperBound: 10050,
+        allowedExchangeRateChangeLowerBound: 9950,
+        minimumUpdateDelayInSeconds: 3600,
+        platformFeeBps: 100,
+        performanceFeeBps: 2000,
+        strategist: authority.publicKey,
+        withdrawAuthority: PublicKey.default, // permissionless
+      })
+      .accounts({
+        signer: authority.publicKey,
+        program: program.programId,
+        config: programConfig,
+        boringVaultState: vaultState,
+        shareMint,
+        baseAsset: WSOL,
+        baseAssetData: PublicKey.default,
+        systemProgram: SystemProgram.programId,
+        tokenProgram: TOKEN_2022_PROGRAM_ID,
+        rent: SYSVAR_RENT_PUBKEY,
+      })
+      .instruction();
+
+    const deployTxResult = await ths.createAndProcessTransaction(
+      client,
+      deployer,
+      deployIx,
+      [authority]
+    );
+    await ths.expectTxToSucceed(deployTxResult);
+  });
+
+  it("Sets a new mint authority", async () => {
+    const setMintAuthIx = await program.methods
+      .setMintAuthority(new anchor.BN(0), newMintAuthority.publicKey)
+      .accounts({
+        signer: authority.publicKey,
+        boringVaultState: vaultState,
+      })
+      .instruction();
+
+    const txResult = await ths.createAndProcessTransaction(
+      client,
+      deployer,
+      setMintAuthIx,
+      [authority]
+    );
+    await ths.expectTxToSucceed(txResult);
+
+    const vaultStateAccount = await program.account.boringVault.fetch(vaultState);
+    assert.equal(
+      vaultStateAccount.config.pendingMintAuthority.toBase58(),
+      newMintAuthority.publicKey.toBase58()
+    );
+  });
+
+  it("Accepts the new mint authority", async () => {
+    const acceptMintAuthIx = await program.methods
+      .acceptMintAuthority(new anchor.BN(0))
+      .accounts({
+        signer: newMintAuthority.publicKey,
+        boringVaultState: vaultState,
+      })
+      .instruction();
+
+    const txResult = await ths.createAndProcessTransaction(
+      client,
+      deployer,
+      acceptMintAuthIx,
+      [newMintAuthority]
+    );
+    await ths.expectTxToSucceed(txResult);
+
+    const vaultStateAccount = await program.account.boringVault.fetch(vaultState);
+    assert.equal(
+      vaultStateAccount.config.currentMintAuthority.toBase58(),
+      newMintAuthority.publicKey.toBase58()
+    );
+    assert.equal(
+      vaultStateAccount.config.pendingMintAuthority.toBase58(),
+      PublicKey.default.toBase58()
+    );
+  });
+
+  it("Mints shares to a user's ATA", async () => {
+    const mintSharesIx = await program.methods
+      .mintShares(new anchor.BN(0), new anchor.BN(1000))
+      .accounts({
+        signer: newMintAuthority.publicKey,
+        boringVaultState: vaultState,
+        shareMint: shareMint,
+        ata: userShareAta,
+        token_program: TOKEN_2022_PROGRAM_ID,
+        token_program_2022: TOKEN_2022_PROGRAM_ID,
+      })
+      .instruction();
+
+    const txResult = await ths.createAndProcessTransaction(
+      client,
+      deployer,
+      mintSharesIx,
+      [newMintAuthority]
+    );
+    await ths.expectTxToSucceed(txResult);
+
+    const ataAccount = await client.getAccount(userShareAta);
+    assert.equal(AccountLayout.decode(ataAccount.data).amount, BigInt(1000));
+  });
+
+  it("Fails to mint shares with invalid authority", async () => {
+    const invalidMintSharesIx = await program.methods
+      .mintShares(new anchor.BN(0), new anchor.BN(1000))
+      .accounts({
+        signer: authority.publicKey,
+        boringVaultState: vaultState,
+        shareMint: shareMint,
+        ata: userShareAta,
+        token_program: TOKEN_2022_PROGRAM_ID,
+        token_program_2022: TOKEN_2022_PROGRAM_ID,
+      })
+      .instruction();
+
+    const txResult = await ths.createAndProcessTransaction(
+      client,
+      deployer,
+      invalidMintSharesIx,
+      [authority]
+    );
+    await ths.expectTxToFail(txResult, "Invalid mint authority");
+  });
+}); 

--- a/tools/Cargo.toml
+++ b/tools/Cargo.toml
@@ -1,0 +1,28 @@
+[package]
+name = "boring-vault-tools"
+version = "0.1.0"
+edition = "2021"
+description = "Tools for querying Boring Vault balances"
+authors = ["Boring Vault Team"]
+
+[lib]
+name = "boring_vault_tools"
+crate-type = ["cdylib", "rlib"]
+
+[dependencies]
+solana-client = "1.18.26"
+solana-sdk = "1.18.26"
+solana-account-decoder = "1.18.26"
+spl-token = "4.0"
+anyhow = "1.0"
+pyo3 = { version = "0.19", features = ["extension-module", "abi3-py37", "auto-initialize"] }
+thiserror = "1.0"
+log = "0.4"
+env_logger = "0.10"
+base64 = "0.21"
+borsh = "1.3"
+
+[dev-dependencies]
+tokio = { version = "1.0", features = ["full"] }
+
+[workspace]

--- a/tools/README.md
+++ b/tools/README.md
@@ -1,0 +1,81 @@
+# Boring Vault Tools
+
+A collection of tools for interacting with the Boring Vault program on Solana.
+
+## Prerequisites
+
+- Python 3.8 or higher
+- Rust toolchain (install via [rustup](https://rustup.rs/))
+- Python development headers (`python3-dev` package on Ubuntu/Debian)
+
+## Installation
+
+1. Create and activate a virtual environment:
+```bash
+python3 -m venv venv
+source venv/bin/activate  # On Windows: venv\Scripts\activate
+```
+
+2. Build the Rust components first:
+```bash
+# Make sure you're in the tools directory
+cd tools
+cargo build --release
+```
+
+3. Install the Python package in development mode:
+```bash
+# Still in the tools directory
+pip install -e .
+```
+
+This will install the Python package using the pre-built Rust components.
+
+4. Ensure there is a `.env` file in the root directory of the project with your Alchemy RPC API key:
+```
+ALCHEMY_API_KEY=your_api_key_here
+```
+
+## Usage
+
+### Querying Vault Information
+
+The `query_vault.py` script allows you to query information about deployed vaults:
+
+```bash
+# Make sure you're in the tools directory
+cd tools
+
+# Run with default settings
+python3 query_vault.py
+
+# Query a specific vault ID
+python3 query_vault.py --vault-id 1
+
+# Use a custom RPC URL
+python3 query_vault.py --rpc-url https://solana-mainnet.g.alchemy.com/v2/
+
+# Query multiple vaults
+python3 query_vault.py --limit 5
+
+# Start from a specific index
+python3 query_vault.py --start-index 10 --limit 5
+```
+
+## Development
+
+### Making Changes
+
+If you modify the Rust code:
+
+```bash
+# Rebuild the Rust library
+cargo build --release
+
+# Reinstall the Python package
+pip install -e .
+```
+
+## License
+
+MIT 

--- a/tools/pyproject.toml
+++ b/tools/pyproject.toml
@@ -1,0 +1,23 @@
+[build-system]
+requires = ["maturin>=1.4,<2.0"]
+build-backend = "maturin"
+
+[project]
+name = "boring-vault-tools"
+version = "0.1.0"
+description = "Tools for interacting with the Boring Vault program"
+requires-python = ">=3.8"
+dependencies = [
+    "requests>=2.31.0",
+    "python-dotenv>=1.1.0",
+    "urllib3>=2.0.7",
+    "certifi>=2023.11.17",
+    "idna>=3.6",
+    "charset-normalizer>=3.4.1",
+    "solana>=0.36.6",
+]
+
+[tool.maturin]
+features = ["pyo3/extension-module"]
+python-source = "src/python"
+module-name = "boring_vault_tools.boring_vault_tools" 

--- a/tools/query_vault.py
+++ b/tools/query_vault.py
@@ -1,0 +1,113 @@
+#!/usr/bin/env python3
+import argparse
+import json
+import base64
+import requests
+import os
+from dotenv import load_dotenv
+from boring_vault_tools import sum_vault_balances
+
+# Load environment variables from .env file
+print(f"Current working directory: {os.getcwd()}")
+load_dotenv()
+api_key = os.getenv("ALCHEMY_API_KEY")
+print(f"API key loaded: {'Yes' if api_key else 'No'}")
+
+# Program ID from source file
+BORING_VAULT_SVM = "5ZRnXG4GsUMLaN7w2DtJV1cgLgcXHmuHCmJ2MxoorWCE"  # Updated program ID
+
+def get_vault_info(program_id, rpc_url):
+    """Get information about vaults deployed by the given program."""
+    api_key = os.getenv("ALCHEMY_API_KEY")
+    if not api_key:
+        raise ValueError("ALCHEMY_API_KEY environment variable not set")
+        
+    headers = {
+        "Content-Type": "application/json",
+        "Authorization": f"Bearer {api_key}"
+    }
+    
+    payload = {
+        "jsonrpc": "2.0",
+        "id": 1,
+        "method": "getProgramAccounts",
+        "params": [
+            program_id,
+            {
+                "encoding": "base64",
+                "commitment": "confirmed"
+            }
+        ]
+    }
+    
+    try:
+        response = requests.post(rpc_url, headers=headers, json=payload)
+        response.raise_for_status()
+        data = response.json()
+        
+        if "result" not in data or data["result"] is None:
+            print(f"No accounts found for program {program_id}")
+            return []
+        
+        vaults = []
+        for account in data["result"]:
+            try:
+                # Try to parse the account data to extract vault ID
+                account_data = base64.b64decode(account["account"]["data"][0])
+                # Assuming vault_id is stored at a specific position in the account data
+                # This is a placeholder and may need to be adjusted
+                vault_id = int.from_bytes(account_data[8:16], byteorder='little')
+                vaults.append({
+                    "pubkey": account["pubkey"],
+                    "vault_id": vault_id
+                })
+            except Exception as e:
+                print(f"Error parsing account {account['pubkey']}: {e}")
+        
+        return vaults
+    except Exception as e:
+        print(f"Error querying program accounts: {e}")
+        return []
+
+def main():
+    parser = argparse.ArgumentParser(description="Query Boring Vault balances")
+    parser.add_argument("--rpc-url", default="https://solana-mainnet.g.alchemy.com/v2/", 
+                        help="Solana RPC URL")
+    parser.add_argument("--vault-id", type=int, help="Specific vault ID to query")
+    parser.add_argument("--limit", type=int, default=1, help="Number of vaults to check (default: 1)")
+    parser.add_argument("--start-index", type=int, default=0, help="Start checking from this index (default: 0)")
+    
+    args = parser.parse_args()
+    
+    # Append API key to RPC URL if using Alchemy
+    if "alchemy.com" in args.rpc_url and not args.rpc_url.endswith(os.getenv("ALCHEMY_API_KEY", "")):
+        args.rpc_url = args.rpc_url.rstrip("/") + "/" + os.getenv("ALCHEMY_API_KEY", "")
+    
+    print(f"\nQuerying Boring Vault program ({BORING_VAULT_SVM})...")
+    vault_accounts = get_vault_info(BORING_VAULT_SVM, args.rpc_url)
+    print(f"Found {len(vault_accounts)} vault accounts")
+    
+    if args.vault_id:
+        # Filter to specific vault ID if provided
+        vault_accounts = [v for v in vault_accounts if v["vault_id"] == args.vault_id]
+        print(f"Filtered to {len(vault_accounts)} vault accounts with ID {args.vault_id}")
+    
+    # Apply start index and limit
+    start = min(args.start_index, len(vault_accounts))
+    end = min(start + args.limit, len(vault_accounts))
+    vault_accounts = vault_accounts[start:end]
+    
+    print(f"\nChecking vaults {start} to {end-1}:")
+    for vault in vault_accounts:
+        print(f"\nVault ID: {vault['vault_id']}")
+        print(f"Vault Address: {vault['pubkey']}")
+        try:
+            balances = sum_vault_balances(args.rpc_url)
+            print(f"SOL: {balances.sol} lamports")
+            print(f"JitoSOL: {balances.jitosol} base units")
+            print(f"wSOL: {balances.wsol} base units")
+        except Exception as e:
+            print(f"Error getting balances: {e}")
+
+if __name__ == "__main__":
+    main() 

--- a/tools/requirements.txt
+++ b/tools/requirements.txt
@@ -1,0 +1,8 @@
+requests==2.31.0
+python-dotenv==1.1.0
+urllib3==2.0.7
+certifi==2023.11.17
+idna==3.6
+charset-normalizer==3.4.1
+solana==0.36.6
+maturin>=1.4,<2.0

--- a/tools/src/lib.rs
+++ b/tools/src/lib.rs
@@ -1,0 +1,245 @@
+use pyo3::prelude::*;
+use log::{info};
+use solana_client::{
+    rpc_client::RpcClient,
+    rpc_request::TokenAccountsFilter,
+};
+use solana_sdk::{
+    pubkey::Pubkey,
+    system_program,
+};
+use spl_token::state::Account as TokenAccount;
+use solana_sdk::program_pack::Pack;
+use std::str::FromStr;
+use base64::{Engine as _, engine::general_purpose::STANDARD as base64};
+
+/// The base seed used for deriving PDAs for vault sub-accounts
+const BASE_SEED_BORING_VAULT: &[u8] = b"boring_vault";
+/// The mint address for JitoSOL token
+const JITOSOL_MINT: &str = "J1toso1uFr7z4g7Bm7sreoCRD67YsP3hC4dKz2NKwAh";
+/// The mint address for wrapped SOL (wSOL) token
+const WSOL_MINT: &str = "So11111111111111111111111111111111111111112";
+
+/// Represents the total balances of SOL, JitoSOL, and wSOL in a vault
+#[pyclass]
+#[derive(Debug, Clone)]
+pub struct VaultBalances {
+    /// Native SOL balance in lamports
+    #[pyo3(get)]
+    pub sol: u64,
+    /// JitoSOL token balance in base units
+    #[pyo3(get)]
+    pub jitosol: u64,
+    /// Wrapped SOL (wSOL) balance in base units
+    #[pyo3(get)]
+    pub wsol: u64,
+}
+
+#[pymethods]
+impl VaultBalances {
+    #[new]
+    fn new() -> Self {
+        Self::default()
+    }
+}
+
+impl Default for VaultBalances {
+    fn default() -> Self {
+        Self {
+            sol: 0,
+            jitosol: 0,
+            wsol: 0,
+        }
+    }
+}
+
+/// Errors that can occur when querying vault balances
+#[derive(Debug, thiserror::Error)]
+pub enum VaultError {
+    /// The number of sub-accounts requested exceeds the maximum allowed (255)
+    #[error("Invalid number of sub-accounts: {0}")]
+    InvalidSubAccountCount(u32),
+    /// An error occurred while making an RPC request
+    #[error("RPC error: {0}")]
+    RpcError(#[from] solana_client::client_error::ClientError),
+    /// The provided mint address is invalid
+    #[error("Invalid mint address: {0}")]
+    InvalidMintAddress(String),
+    /// Failed to decode account data from base64
+    #[error("Failed to decode account data: {0}")]
+    DecodeError(String),
+}
+
+impl From<VaultError> for PyErr {
+    fn from(err: VaultError) -> PyErr {
+        PyErr::new::<pyo3::exceptions::PyRuntimeError, _>(err.to_string())
+    }
+}
+
+/// Sums up the total SOL, JitoSOL, and wSOL balances across the first N sub-accounts of a vault
+///
+/// # Arguments
+///
+/// * `rpc_url` - The URL of the Solana RPC endpoint to use
+///
+/// # Returns
+///
+/// Returns a `Result` containing either:
+/// * `VaultBalances` - The total balances of SOL, JitoSOL, and wSOL
+/// * `Error` - An error that occurred during the query
+///
+/// # Example
+///
+/// ```no_run
+/// use boring_vault_tools::sum_vault_balances;
+///
+/// let balances = sum_vault_balances(
+///     "https://api.mainnet-beta.solana.com",
+/// ).unwrap();
+///
+/// println!("Total SOL: {} lamports", balances.sol);
+/// println!("Total JitoSOL: {}", balances.jitosol);
+/// println!("Total wSOL: {}", balances.wsol);
+/// ```
+#[pyfunction]
+pub fn sum_vault_balances(
+    rpc_url: &str,
+) -> PyResult<VaultBalances> {
+    let client = RpcClient::new(rpc_url.to_string());
+    let mut balances = VaultBalances::default();
+    let num_sub_accounts = 255; // Maximum number of sub-accounts
+
+    // Get mint pubkeys
+    let jitosol_mint = Pubkey::from_str(JITOSOL_MINT)
+        .map_err(|_| VaultError::InvalidMintAddress(JITOSOL_MINT.to_string()))?;
+    let wsol_mint = Pubkey::from_str(WSOL_MINT)
+        .map_err(|_| VaultError::InvalidMintAddress(WSOL_MINT.to_string()))?;
+
+    // Test the RPC connection first
+    client.get_version().map_err(VaultError::RpcError)?;
+
+    for sub_account in 0..num_sub_accounts {
+        let (pda, _) = Pubkey::find_program_address(
+            &[
+                BASE_SEED_BORING_VAULT,
+                &[sub_account as u8],
+            ],
+            &system_program::id(),
+        );
+
+        // Get SOL balance
+        match client.get_account(&pda) {
+            Ok(account) => {
+                balances.sol += account.lamports;
+            }
+            Err(e) => {
+                // Only ignore AccountNotFound errors
+                if !e.to_string().contains("AccountNotFound") {
+                    return Err(VaultError::RpcError(e).into());
+                }
+            }
+        }
+
+        // Get JitoSOL and wSOL balances
+        match client.get_token_accounts_by_owner(
+            &pda,
+            TokenAccountsFilter::ProgramId(spl_token::id()),
+        ) {
+            Ok(token_accounts) => {
+                for account in token_accounts {
+                    let data = match account.account.data {
+                        solana_account_decoder::UiAccountData::Binary(data, _) => {
+                            base64.decode(data)
+                                .map_err(|e| VaultError::DecodeError(e.to_string()))?
+                        }
+                        _ => continue,
+                    };
+
+                    if let Ok(token_account) = TokenAccount::unpack(&data) {
+                        if token_account.mint == jitosol_mint {
+                            balances.jitosol += token_account.amount;
+                        } else if token_account.mint == wsol_mint {
+                            balances.wsol += token_account.amount;
+                        }
+                    }
+                }
+            }
+            Err(e) => {
+                // Only ignore AccountNotFound errors
+                if !e.to_string().contains("AccountNotFound") {
+                    return Err(VaultError::RpcError(e).into());
+                }
+            }
+        }
+    }
+
+    info!(
+        "Vault balances: SOL={}, JitoSOL={}, wSOL={}",
+        balances.sol, balances.jitosol, balances.wsol
+    );
+
+    Ok(balances)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::str::FromStr;
+
+    #[test]
+    fn test_invalid_rpc_url() {
+        let result = sum_vault_balances("http://invalid-url:8899");
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_invalid_mint_address() {
+        let invalid_mint = "invalid_address";
+        let result = Pubkey::from_str(invalid_mint);
+        assert!(result.is_err());
+
+        // Test that our error handling works in the main function
+        let result = Pubkey::from_str(invalid_mint)
+            .map_err(|_| VaultError::InvalidMintAddress(invalid_mint.to_string()));
+        assert!(result.is_err());
+        assert!(matches!(result, Err(VaultError::InvalidMintAddress(_))));
+    }
+
+    #[test]
+    fn test_pda_derivation() {
+        let vault_id = 123u64;
+        let sub_account = 0u8;
+        let (pda, _) = Pubkey::find_program_address(
+            &[
+                BASE_SEED_BORING_VAULT,
+                &vault_id.to_le_bytes(),
+                &[sub_account],
+            ],
+            &system_program::id(),
+        );
+        assert!(pda != Pubkey::default());
+    }
+
+    #[test]
+    fn test_mint_addresses() {
+        // Verify that the mint addresses are valid Pubkeys
+        assert!(Pubkey::from_str(JITOSOL_MINT).is_ok());
+        assert!(Pubkey::from_str(WSOL_MINT).is_ok());
+    }
+
+    #[test]
+    fn test_vault_balances_default() {
+        let balances = VaultBalances::default();
+        assert_eq!(balances.sol, 0);
+        assert_eq!(balances.jitosol, 0);
+        assert_eq!(balances.wsol, 0);
+    }
+}
+
+/// Python module initialization
+#[pymodule]
+fn boring_vault_tools(_py: Python<'_>, m: &PyModule) -> PyResult<()> {
+    m.add_class::<VaultBalances>()?;
+    m.add_function(wrap_pyfunction!(sum_vault_balances, m)?)?;
+    Ok(())
+} 

--- a/tools/src/python/boring_vault_tools/__init__.py
+++ b/tools/src/python/boring_vault_tools/__init__.py
@@ -1,0 +1,3 @@
+from .boring_vault_tools import sum_vault_balances
+
+__version__ = "0.1.0" 

--- a/tools/src/python/mod.rs
+++ b/tools/src/python/mod.rs
@@ -1,0 +1,44 @@
+use pyo3::prelude::*;
+use pyo3::types::PyDict;
+use std::str::FromStr;
+
+use crate::sum_vault_balances;
+
+#[pymodule]
+fn boring_vault_tools(_py: Python<'_>, m: &PyModule) -> PyResult<()> {
+    m.add_function(wrap_pyfunction!(get_vault_balances, m)?)?;
+    Ok(())
+}
+
+#[pyfunction]
+fn get_vault_balances(
+    vault_id: u64,
+    num_sub_accounts: u32,
+    rpc_url: &str,
+) -> PyResult<PyObject> {
+    Python::with_gil(|py| {
+        match sum_vault_balances(vault_id, num_sub_accounts, rpc_url) {
+            Ok(balances) => {
+                let dict = PyDict::new(py);
+                dict.set_item("sol", balances.sol)?;
+                dict.set_item("jitosol", balances.jitosol)?;
+                dict.set_item("wsol", balances.wsol)?;
+                Ok(dict.into())
+            }
+            Err(e) => Err(PyErr::new::<pyo3::exceptions::PyRuntimeError, _>(e.to_string())),
+        }
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_python_bindings() {
+        Python::with_gil(|py| {
+            let result = get_vault_balances(1, 5, "http://localhost:8899");
+            assert!(result.is_err()); // Should fail with invalid RPC URL
+        });
+    }
+} 

--- a/yarn.lock
+++ b/yarn.lock
@@ -14,7 +14,7 @@
   resolved "https://registry.npmjs.org/@coral-xyz/anchor-errors/-/anchor-errors-0.30.1.tgz"
   integrity sha512-9Mkradf5yS5xiLWrl9WrpjqOrAV+/W2RQHDlbnAZBivoGpOs1ECjoDCkVk4aRG8ZdiFiB8zQEVlxf+8fKkmSfQ==
 
-"@coral-xyz/anchor@^0.30.0", "@coral-xyz/anchor@^0.30.1":
+"@coral-xyz/anchor@^0.30.1":
   version "0.30.1"
   resolved "https://registry.npmjs.org/@coral-xyz/anchor/-/anchor-0.30.1.tgz"
   integrity sha512-gDXFoF5oHgpriXAaLpxyWBHdCs8Awgf/gLHIo6crv7Aqm937CNdY+x+6hoj7QR5vaJV7MxWSQ0NGFzL3kPbWEQ==
@@ -50,7 +50,7 @@
   dependencies:
     "@noble/hashes" "1.5.0"
 
-"@noble/hashes@^1.3.1", "@noble/hashes@^1.4.0", "@noble/hashes@1.5.0":
+"@noble/hashes@1.5.0", "@noble/hashes@^1.3.1", "@noble/hashes@^1.4.0":
   version "1.5.0"
   resolved "https://registry.npmjs.org/@noble/hashes/-/hashes-1.5.0.tgz"
   integrity sha512-1j6kQFb7QRru7eKN3ZDvRcP13rugwdxZqCjbiAVZfIJwgj2A65UmT4TgARXGlXgnRkORLTDTrO19ZErt7+QXgA==
@@ -160,7 +160,7 @@
     "@solana/spl-token-metadata" "^0.1.6"
     buffer "^6.0.3"
 
-"@solana/web3.js@^1.32.0", "@solana/web3.js@^1.68.0", "@solana/web3.js@^1.95.3", "@solana/web3.js@>1.92.0":
+"@solana/web3.js@^1.32.0", "@solana/web3.js@^1.68.0":
   version "1.95.4"
   resolved "https://registry.npmjs.org/@solana/web3.js/-/web3.js-1.95.4.tgz"
   integrity sha512-sdewnNEA42ZSMxqkzdwEWi6fDgzwtJHaQa5ndUGEJYtoOnM6X5cvPmjoTUp7/k7bRrVAxfBgDnvQQHD6yhlLYw==
@@ -252,6 +252,14 @@
   version "1.1.2"
   resolved "https://registry.npmjs.org/@ungap/promise-all-settled/-/promise-all-settled-1.1.2.tgz"
   integrity sha512-sL/cEvJWAnClXw0wHk85/2L0G6Sj8UB0Ctc1TEMbKSsmpRosqhwj9gWgFRZSrBr2f9tiXISwNhCPmlfqUqyb9Q==
+
+JSONStream@^1.3.5:
+  version "1.3.5"
+  resolved "https://registry.npmjs.org/JSONStream/-/JSONStream-1.3.5.tgz"
+  integrity sha512-E+iruNOY8VV9s4JEbe1aNEm6MiszPRr/UfcHMz0TQh1BXSxHK+ASV1R6W4HpjBhSeS+54PIsAMCBmwD06LLsqQ==
+  dependencies:
+    jsonparse "^1.2.0"
+    through ">=2.2.7 <3"
 
 agentkeepalive@^4.5.0:
   version "4.5.0"
@@ -385,14 +393,7 @@ browser-stdout@1.3.1:
   resolved "https://registry.npmjs.org/browser-stdout/-/browser-stdout-1.3.1.tgz"
   integrity sha512-qhAVI1+Av2X7qelOfAIYwXONood6XlZE/fXaBSmW/T5SzLAmCgzi+eiWE7fUvbHaeNBQH13UftjpXxsfLkMpgw==
 
-bs58@^4.0.0:
-  version "4.0.1"
-  resolved "https://registry.npmjs.org/bs58/-/bs58-4.0.1.tgz"
-  integrity sha512-Ok3Wdf5vOIlBrgCvTq96gBkJw+JUEzdBgyaza5HLtPm7yTHkjRy8+JzNyHF7BHa0bNWOQIp3m5YF0nnFcOIKLw==
-  dependencies:
-    base-x "^3.0.2"
-
-bs58@^4.0.1:
+bs58@^4.0.0, bs58@^4.0.1:
   version "4.0.1"
   resolved "https://registry.npmjs.org/bs58/-/bs58-4.0.1.tgz"
   integrity sha512-Ok3Wdf5vOIlBrgCvTq96gBkJw+JUEzdBgyaza5HLtPm7yTHkjRy8+JzNyHF7BHa0bNWOQIp3m5YF0nnFcOIKLw==
@@ -416,7 +417,7 @@ buffer-layout@^1.2.0, buffer-layout@^1.2.2:
   resolved "https://registry.npmjs.org/buffer-layout/-/buffer-layout-1.2.2.tgz"
   integrity sha512-kWSuLN694+KTk8SrYvCqwP2WcgQjoRCiF5b4QDvkkz8EmgD+aWAIceGFKMIAdmF/pH+vpgNV3d3kAKorcdAmWA==
 
-buffer@^6.0.3, buffer@~6.0.3, buffer@6.0.3:
+buffer@6.0.3, buffer@^6.0.3, buffer@~6.0.3:
   version "6.0.3"
   resolved "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz"
   integrity sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==
@@ -556,15 +557,15 @@ delay@^5.0.0:
   resolved "https://registry.npmjs.org/delay/-/delay-5.0.0.tgz"
   integrity sha512-ReEBKkIfe4ya47wlPYf/gu5ib6yUG0/Aez0JQZQz94kiWtRQvZIQbTiehsnwHvLSWJnQdhVeqYue7Id1dKr0qw==
 
-diff@^3.1.0:
-  version "3.5.0"
-  resolved "https://registry.npmjs.org/diff/-/diff-3.5.0.tgz"
-  integrity sha512-A46qtFgd+g7pDZinpnwiRJtxbC1hpgf0uzP3iG89scHk0AUC7A1TGxf5OiiOUv/JMZR8GOt8hL900hV0bOy5xA==
-
 diff@5.0.0:
   version "5.0.0"
   resolved "https://registry.npmjs.org/diff/-/diff-5.0.0.tgz"
   integrity sha512-/VTCrvm5Z0JGty/BWHljh+BAiw3IK+2j87NGMu8Nwc/f48WoDAC395uomO9ZD117ZOBaHmkX1oyLvkVM/aIT3w==
+
+diff@^3.1.0:
+  version "3.5.0"
+  resolved "https://registry.npmjs.org/diff/-/diff-3.5.0.tgz"
+  integrity sha512-A46qtFgd+g7pDZinpnwiRJtxbC1hpgf0uzP3iG89scHk0AUC7A1TGxf5OiiOUv/JMZR8GOt8hL900hV0bOy5xA==
 
 dot-case@^3.0.4:
   version "3.0.4"
@@ -625,11 +626,6 @@ fast-stable-stringify@^1.0.0:
   version "1.0.0"
   resolved "https://registry.npmjs.org/fast-stable-stringify/-/fast-stable-stringify-1.0.0.tgz"
   integrity sha512-wpYMUmFu5f00Sm0cj2pfivpmawLZ0NKdviQ4w9zJeR8JVtOpOxHmLaJuj0vxvGqMJQWyP/COUkF75/57OKyRag==
-
-fastestsmallesttextencoderdecoder@^1.0.22:
-  version "1.0.22"
-  resolved "https://registry.npmjs.org/fastestsmallesttextencoderdecoder/-/fastestsmallesttextencoderdecoder-1.0.22.tgz"
-  integrity sha512-Pb8d48e+oIuY4MaM64Cd7OW1gt4nxCHs7/ddPPZ/Ic3sg8yVGM7O9wDvZ7us6ScaUupzM+pfBolwtYhN1IxBIw==
 
 file-uri-to-path@1.0.0:
   version "1.0.0"
@@ -792,13 +788,13 @@ jayson@^4.1.1:
     "@types/connect" "^3.4.33"
     "@types/node" "^12.12.54"
     "@types/ws" "^7.4.4"
+    JSONStream "^1.3.5"
     commander "^2.20.3"
     delay "^5.0.0"
     es6-promisify "^5.0.0"
     eyes "^0.1.8"
     isomorphic-ws "^4.0.1"
     json-stringify-safe "^5.0.1"
-    JSONStream "^1.3.5"
     uuid "^8.3.2"
     ws "^7.5.10"
 
@@ -825,14 +821,6 @@ jsonparse@^1.2.0:
   version "1.3.1"
   resolved "https://registry.npmjs.org/jsonparse/-/jsonparse-1.3.1.tgz"
   integrity sha512-POQXvpdL69+CluYsillJ7SUhKvytYjW9vG/GKpnf+xP8UWgYEM/RaMzHHofbALDiKbbP1W8UEYmgGl39WkPZsg==
-
-JSONStream@^1.3.5:
-  version "1.3.5"
-  resolved "https://registry.npmjs.org/JSONStream/-/JSONStream-1.3.5.tgz"
-  integrity sha512-E+iruNOY8VV9s4JEbe1aNEm6MiszPRr/UfcHMz0TQh1BXSxHK+ASV1R6W4HpjBhSeS+54PIsAMCBmwD06LLsqQ==
-  dependencies:
-    jsonparse "^1.2.0"
-    through ">=2.2.7 <3"
 
 locate-path@^6.0.0:
   version "6.0.0"
@@ -868,17 +856,17 @@ make-error@^1.1.1:
   resolved "https://registry.npmjs.org/make-error/-/make-error-1.3.6.tgz"
   integrity sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw==
 
-minimatch@^3.0.4:
-  version "3.1.2"
-  resolved "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz"
-  integrity sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==
-  dependencies:
-    brace-expansion "^1.1.7"
-
 minimatch@4.2.1:
   version "4.2.1"
   resolved "https://registry.npmjs.org/minimatch/-/minimatch-4.2.1.tgz"
   integrity sha512-9Uq1ChtSZO+Mxa/CL1eGizn2vRn3MlLgzhT0Iz8zaY8NdvxvB0d5QdPFmCKf7JKA9Lerx5vRrnwO03jsSfGG9g==
+  dependencies:
+    brace-expansion "^1.1.7"
+
+minimatch@^3.0.4:
+  version "3.1.2"
+  resolved "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz"
+  integrity sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==
   dependencies:
     brace-expansion "^1.1.7"
 
@@ -894,7 +882,7 @@ mkdirp@^0.5.1:
   dependencies:
     minimist "^1.2.6"
 
-"mocha@^3.X.X || ^4.X.X || ^5.X.X || ^6.X.X || ^7.X.X || ^8.X.X || ^9.X.X || ^10.X.X", mocha@^9.0.3:
+mocha@^9.0.3:
   version "9.2.2"
   resolved "https://registry.npmjs.org/mocha/-/mocha-9.2.2.tgz"
   integrity sha512-L6XC3EdwT6YrIk0yXpavvLkn8h+EU+Y5UcCHKECyMbdUIxyMuZj4bX4U9e1nvnvUUvQVsV2VHQr5zLdcUkhW/g==
@@ -924,15 +912,15 @@ mkdirp@^0.5.1:
     yargs-parser "20.2.4"
     yargs-unparser "2.0.0"
 
-ms@^2.0.0, ms@2.1.3:
-  version "2.1.3"
-  resolved "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz"
-  integrity sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==
-
 ms@2.1.2:
   version "2.1.2"
   resolved "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz"
   integrity sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==
+
+ms@2.1.3, ms@^2.0.0:
+  version "2.1.3"
+  resolved "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz"
+  integrity sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==
 
 nanoid@3.3.1:
   version "3.3.1"
@@ -1085,7 +1073,22 @@ solana-bankrun-darwin-universal@0.4.0:
   resolved "https://registry.npmjs.org/solana-bankrun-darwin-universal/-/solana-bankrun-darwin-universal-0.4.0.tgz"
   integrity sha512-zSSw/Jx3KNU42pPMmrEWABd0nOwGJfsj7nm9chVZ3ae7WQg3Uty0hHAkn5NSDCj3OOiN0py9Dr1l9vmRJpOOxg==
 
-solana-bankrun@^0.4.0, "solana-bankrun@>=0.2.0 <0.5.0":
+solana-bankrun-darwin-x64@0.4.0:
+  version "0.4.0"
+  resolved "https://registry.yarnpkg.com/solana-bankrun-darwin-x64/-/solana-bankrun-darwin-x64-0.4.0.tgz#f863c5a668858b7c44be51376bd05fb077c11c99"
+  integrity sha512-LWjs5fsgHFtyr7YdJR6r0Ho5zrtzI6CY4wvwPXr8H2m3b4pZe6RLIZjQtabCav4cguc14G0K8yQB2PTMuGub8w==
+
+solana-bankrun-linux-x64-gnu@0.4.0:
+  version "0.4.0"
+  resolved "https://registry.yarnpkg.com/solana-bankrun-linux-x64-gnu/-/solana-bankrun-linux-x64-gnu-0.4.0.tgz#30fd7edaf3ff6585468138d3bed6eaed37878d9e"
+  integrity sha512-SrlVrb82UIxt21Zr/XZFHVV/h9zd2/nP25PMpLJVLD7Pgl2yhkhfi82xj3OjxoQqWe+zkBJ+uszA0EEKr67yNw==
+
+solana-bankrun-linux-x64-musl@0.4.0:
+  version "0.4.0"
+  resolved "https://registry.yarnpkg.com/solana-bankrun-linux-x64-musl/-/solana-bankrun-linux-x64-musl-0.4.0.tgz#3c870218140b1307dc44b51d2282697c99f2e1e4"
+  integrity sha512-Nv328ZanmURdYfcLL+jwB1oMzX4ZzK57NwIcuJjGlf0XSNLq96EoaO5buEiUTo4Ls7MqqMyLbClHcrPE7/aKyA==
+
+solana-bankrun@^0.4.0:
   version "0.4.0"
   resolved "https://registry.npmjs.org/solana-bankrun/-/solana-bankrun-0.4.0.tgz"
   integrity sha512-NMmXUipPBkt8NgnyNO3SCnPERP6xT/AMNMBooljGA3+rG6NN8lmXJsKeLqQTiFsDeWD74U++QM/DgcueSWvrIg==
@@ -1148,17 +1151,17 @@ superstruct@^2.0.2:
   resolved "https://registry.npmjs.org/superstruct/-/superstruct-2.0.2.tgz"
   integrity sha512-uV+TFRZdXsqXTL2pRvujROjdZQ4RAlBUS5BTh9IGm+jTqQntYThciG/qu57Gs69yjnVUSqdxF9YLmSnpupBW9A==
 
-supports-color@^7.1.0:
-  version "7.2.0"
-  resolved "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz"
-  integrity sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==
-  dependencies:
-    has-flag "^4.0.0"
-
 supports-color@8.1.1:
   version "8.1.1"
   resolved "https://registry.npmjs.org/supports-color/-/supports-color-8.1.1.tgz"
   integrity sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==
+  dependencies:
+    has-flag "^4.0.0"
+
+supports-color@^7.1.0:
+  version "7.2.0"
+  resolved "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz"
+  integrity sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==
   dependencies:
     has-flag "^4.0.0"
 
@@ -1237,17 +1240,12 @@ typescript@^4.3.5:
   resolved "https://registry.npmjs.org/typescript/-/typescript-4.9.5.tgz"
   integrity sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==
 
-typescript@>=5:
-  version "5.7.3"
-  resolved "https://registry.npmjs.org/typescript/-/typescript-5.7.3.tgz"
-  integrity sha512-84MVSjMEHP+FQRPy3pX9sTVV/INIex71s9TL2Gm5FG/WG1SqXeKyZ0k7/blY/4FdOzI12CBy1vGc4og/eus0fw==
-
 undici-types@~6.19.8:
   version "6.19.8"
   resolved "https://registry.npmjs.org/undici-types/-/undici-types-6.19.8.tgz"
   integrity sha512-ve2KP6f/JnbPBFyobGHuerC9g1FYGn/F8n1LWTwNxCEzd6IfqTwUQcNXgEtmmQ6DlRrC1hrSrBnCZPokRrDHjw==
 
-utf-8-validate@^5.0.2, utf-8-validate@>=5.0.2:
+utf-8-validate@^5.0.2:
   version "5.0.10"
   resolved "https://registry.npmjs.org/utf-8-validate/-/utf-8-validate-5.0.10.tgz"
   integrity sha512-Z6czzLq4u8fPOyx7TU6X3dvUZVvoJmxSQ+IcrlmagKhilxlhZgxPK6C5Jqbkw1IDUmFTM+cz9QDnnLTwDz/2gQ==
@@ -1298,7 +1296,7 @@ wrappy@1:
   resolved "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz"
   integrity sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==
 
-ws@*, ws@^7.5.10:
+ws@^7.5.10:
   version "7.5.10"
   resolved "https://registry.npmjs.org/ws/-/ws-7.5.10.tgz"
   integrity sha512-+dbF1tHwZpXcbOJdVOkzLDxZP1ailvSxM6ZweXTegylPny803bFhA+vqBYw4s31NSAk4S2Qz+AKXK9a4wkdjcQ==
@@ -1313,15 +1311,15 @@ y18n@^5.0.5:
   resolved "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz"
   integrity sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==
 
-yargs-parser@^20.2.2:
-  version "20.2.9"
-  resolved "https://registry.npmjs.org/yargs-parser/-/yargs-parser-20.2.9.tgz"
-  integrity sha512-y11nGElTIV+CT3Zv9t7VKl+Q3hTQoT9a1Qzezhhl6Rp21gJ/IVTW7Z3y9EWXhuUBC2Shnf+DX0antecpAwSP8w==
-
 yargs-parser@20.2.4:
   version "20.2.4"
   resolved "https://registry.npmjs.org/yargs-parser/-/yargs-parser-20.2.4.tgz"
   integrity sha512-WOkpgNhPTlE73h4VFAFsOnomJVaovO8VqLDzy5saChRBFQFBoMYirowyW+Q9HB4HFF4Z7VZTiG3iSzJJA29yRA==
+
+yargs-parser@^20.2.2:
+  version "20.2.9"
+  resolved "https://registry.npmjs.org/yargs-parser/-/yargs-parser-20.2.9.tgz"
+  integrity sha512-y11nGElTIV+CT3Zv9t7VKl+Q3hTQoT9a1Qzezhhl6Rp21gJ/IVTW7Z3y9EWXhuUBC2Shnf+DX0antecpAwSP8w==
 
 yargs-unparser@2.0.0:
   version "2.0.0"


### PR DESCRIPTION
- **Mint authority transfer and share issuance functions added.**
- **Add python bindings and rust script to calculate total holdings in vault.**
- **Switch back to Veda program IDs so it works for them.**

## Program IDs

I set the program IDs back to what they should be. I did testing for the mint authority with my own IDs because I didn't have your keys. I think we should use a env! macro to sort this out. 

## Mint Authority

The current implementation requires the next authority to accept in order to transfer. This does seem safer from human error than the standard SetAuthority function, and fits with some other patterns you have. 

If I were to redo this, I'd try to refactor the vault code to adhere to SPL Token Program, though. SetAuthority is a standard function there, and I lean towards using standard functions where they fit. I think it's the same for mint. I think a conversation with the current writer to explain the setup and why we have it this way would help. Security is related to simplicity and standardization in code. 

## Python Bindings

Getting the python directory to coexist with the overall project was actually somewhat challenging due to version conflicts. 

It did find 21 vaults associated with the program ID for the vault though, so it seems like it works? It didn't find any SOL after computing computing. You'll have to let me know if that's the expected result. Not sure if you have deployed anything to some of these vaults? I only looked at a few of the 21.

The general idea is that you build the rust script, then python can call it. It feels slow, but I think that might be solved with getting faster compute units from Alchemy. 

## Testing

Added unit tests for mint authority changes. 

Added unit test for python script, but the real test was executing against the existing deployed contract. 